### PR TITLE
Suffix suggestion improvement in phonetic method

### DIFF
--- a/src/utility.rs
+++ b/src/utility.rs
@@ -28,6 +28,14 @@ impl Utility for char {
     }
 }
 
+/// Checks if the `vec` already has the `value` before inserting.
+/// If it does, then the `value` is not inserted.
+pub(crate) fn push_checked<T: PartialEq>(vec: &mut Vec<T>, value: T) {
+    if !vec.contains(&value) {
+        vec.push(value);
+    }
+}
+
 /// Tuple of modifier keys.
 ///
 /// First  is Shift, second is AltGr.


### PR DESCRIPTION
* Fix the misordering of the suggestion list when a suffix added.
* Auto Corrected suggestion should be the first one even a suffix being added.
* Use match instead of nested if
* Remove the use of `str::trim_end_matches` as it does redundant work.

