### PR TITLE
Remove Rayon and gain speedups! :rocket: 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,10 @@ bench = []
 codegen-units = 1
 
 [dependencies]
+ahash = "0.7"
 either = "1.6"
 serde_json = "1.0"
 regex = "1.3"
 stringplus = "0.1"
 edit-distance = "2.1"
 okkhor = "0.4"
-rayon = "1.4"
-hashbrown = { version = "0.8", features = ["rayon", "serde"] }

--- a/src/phonetic/method.rs
+++ b/src/phonetic/method.rs
@@ -1,6 +1,7 @@
 // Phonetic Method
-use hashbrown::HashMap;
+use std::collections::HashMap;
 use std::fs::{read_to_string, write};
+use ahash::RandomState;
 
 use crate::context::Method;
 use crate::config::{Config, get_phonetic_method_defaults};
@@ -13,7 +14,7 @@ pub(crate) struct PhoneticMethod {
     buffer: String,
     suggestion: PhoneticSuggestion,
     // Candidate selections.
-    selections: HashMap<String, String>,
+    selections: HashMap<String, String, RandomState>,
     // Previously selected candidate index of the current suggestion list.
     prev_selection: usize,
 }
@@ -25,7 +26,7 @@ impl PhoneticMethod {
             if let Ok(file) = read_to_string(config.get_user_phonetic_selection_data()) {
                 serde_json::from_str(&file).unwrap()
             } else {
-                HashMap::new()
+                HashMap::with_hasher(RandomState::new())
             };
 
         PhoneticMethod {
@@ -115,7 +116,7 @@ impl Default for PhoneticMethod {
         PhoneticMethod {
             buffer: String::new(),
             suggestion: PhoneticSuggestion::new(&config),
-            selections: HashMap::new(),
+            selections: HashMap::with_hasher(RandomState::new()),
             prev_selection: 0,
         }
     }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -117,26 +117,6 @@ pub(crate) fn split_string(input: &str, include_colon: bool) -> (&str, &str, &st
     (first_part, middle_part, last_part)
 }
 
-#[macro_export]
-/// A helper macro for initializing HashMap.
-/// Originally from the `maplit` crate but customized for using with `hashbrown::HashMap`.
-macro_rules! hashmap {
-    (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
-
-    ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {
-        {
-            let _cap = hashmap!(@count $($key),*);
-            let mut _map = hashbrown::HashMap::with_capacity(_cap);
-            $(
-                let _ = _map.insert($key, $value);
-            )*
-            _map
-        }
-    };
-}
-
 #[cfg(test)]
 mod test {
     use super::{get_modifiers, split_string, Utility};


### PR DESCRIPTION
:rocket: :rocket: :rocket: 

```
 name                                                          master ns/iter  without_rayon ns/iter  diff ns/iter   diff %  speedup 
 fixed::database::benches::bench_fixed_database_ains           341,950         195,859                    -146,091  -42.72%   x 1.75 
 fixed::database::benches::bench_fixed_database_ama            349,697         176,053                    -173,644  -49.66%   x 1.99 
 fixed::database::benches::bench_fixed_database_compiu         773,281         431,292                    -341,989  -44.23%   x 1.79 
 phonetic::database::benches::bench_phonetic_database_a        799,585         464,479                    -335,106  -41.91%   x 1.72 
 phonetic::database::benches::bench_phonetic_database_aro      850,701         528,568                    -322,133  -37.87%   x 1.61 
 phonetic::database::benches::bench_phonetic_database_bistari  1,226,474       744,485                    -481,989  -39.30%   x 1.65 
 phonetic::suggestion::benches::bench_phonetic_a               757,574         469,955                    -287,619  -37.97%   x 1.61 
 phonetic::suggestion::benches::bench_phonetic_bistari         1,144,380       748,052                    -396,328  -34.63%   x 1.53 
 phonetic::suggestion::benches::bench_phonetic_kkhet           1,044,603       677,948                    -366,655  -35.10%   x 1.54 
```

This also removes the `hashbrown` crate as it is used as the default implementation of the `std::collections::HashMap` and adds the `ahash` crate for faster hashing(previously the default hasher for `hashbrown`).

Thanks @gulshan for observing the initial perf and suggesting to remove `rayon`!