### PR TITLE
Don't need to allocate a vector of `CString`s over the FFI boundary

### DIFF
--- a/include/riti.h
+++ b/include/riti.h
@@ -265,6 +265,8 @@ struct RitiContext;
 
 /*
  Suggestions which are intended to be shown by the IM's candidate window.
+ Suggestion is of two variants, the 'Full' one includes a list of suggestion and
+ the 'Single' one is just a String.
  */
 struct Suggestion;
 
@@ -319,13 +321,10 @@ Suggestion *riti_context_backspace_event(RitiContext *ptr);
 
 void riti_suggestion_free(Suggestion *ptr);
 
-char **riti_suggestion_get_suggestions(const Suggestion *ptr);
-
 /*
- Free the string array `ptr` of `len` length previously allocated by other function.
+ Get the suggestion of the `index` from suggestions.
  */
-void riti_string_array_free(char **ptr,
-                            uintptr_t len);
+char *riti_suggestion_get_suggestion(const Suggestion *ptr, uintptr_t index);
 
 /*
  Get the only suggestion of the *lonely* `Suggestion`.

--- a/src/context.rs
+++ b/src/context.rs
@@ -113,7 +113,7 @@ mod tests {
         context.get_suggestion_for_key(VC_L, 0);
         let suggestion = context.get_suggestion_for_key(VC_P, 0);
         context.finish_input_session();
-        assert_eq!(suggestion.get_suggestions().collect::<Vec<_>>(), ["হেল্প", "🆘"]);
+        assert_eq!(suggestion.get_suggestions(), ["হেল্প", "🆘"]);
 
         // Change the layout to Fixed layout
         let config = get_fixed_method_defaults();
@@ -124,6 +124,6 @@ mod tests {
         context.get_suggestion_for_key(VC_L, 0);
         let suggestion = context.get_suggestion_for_key(VC_P, 0);
         context.finish_input_session();
-        assert_eq!(suggestion.get_suggestions().collect::<Vec<_>>(), ["হীলপ"]);
+        assert_eq!(suggestion.get_suggestions(), ["হীলপ"]);
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -129,47 +129,18 @@ pub extern "C" fn riti_suggestion_free(ptr: *mut Suggestion) {
     }
 }
 
+/// Get the suggestion of the `index` from suggestions.
 #[no_mangle]
-pub extern "C" fn riti_suggestion_get_suggestions(ptr: *const Suggestion) -> *mut *mut c_char {
+pub extern "C" fn riti_suggestion_get_suggestion(ptr: *const Suggestion, index: usize) -> *mut c_char {
     let suggestion = unsafe {
         assert!(!ptr.is_null());
         &*ptr
     };
 
-    let mut res_vec = Vec::with_capacity(suggestion.len());
-
-    for string in suggestion.get_suggestions() {
-        unsafe {
-            res_vec.push(CString::from_vec_unchecked(string.as_bytes().into()).into_raw());
-        }
-    }
-
-    // Shrink capacity close to the length and ensure that it's equal in size.
-    res_vec.shrink_to_fit();
-    assert_eq!(res_vec.capacity(), res_vec.len());
-
-    // Here we leak the memory for giving the ownership.
-    let res = res_vec.as_mut_ptr();
-    std::mem::forget(res_vec);
-    res
-}
-
-/// Free the string array `ptr` of `len` length previously allocated by other function.
-#[no_mangle]
-pub extern "C" fn riti_string_array_free(ptr: *mut *mut c_char, len: usize) {
-    if ptr.is_null() {
-        return;
-    }
+    let string = suggestion.get_suggestions()[index].clone();
 
     unsafe {
-        // Safe because we ensure that the capacity and the length of the vector 
-        // is same while returning a pointer of that vector.
-        let vec = Vec::from_raw_parts(ptr, len, len);
-        
-        // Now reconstitute the values to properly deallocate them.
-        for item in vec {
-            CString::from_raw(item);
-        }
+        CString::from_vec_unchecked(string.into()).into_raw()
     }
 }
 

--- a/src/fixed/method.rs
+++ b/src/fixed/method.rs
@@ -170,13 +170,13 @@ impl FixedMethod {
             self.suggestions.truncate(9);
         }
 
-        Suggestion::new(self.buffer.clone(), self.suggestions.clone(), 0)
+        Suggestion::new(self.buffer.clone(), &self.suggestions, 0)
     }
 
     fn current_suggestion(&self, config: &Config) -> Suggestion {
         if !self.buffer.is_empty() {
             if config.get_fixed_suggestion() {
-                Suggestion::new(self.buffer.clone(), self.suggestions.clone(), 0)
+                Suggestion::new(self.buffer.clone(), &self.suggestions, 0)
             } else {
                 Suggestion::new_lonely(self.buffer.clone())
             }

--- a/src/phonetic/method.rs
+++ b/src/phonetic/method.rs
@@ -66,7 +66,7 @@ impl PhoneticMethod {
 
             self.prev_selection = selection;
 
-            Suggestion::new(self.buffer.clone(), suggestions, self.prev_selection)
+            Suggestion::new(self.buffer.clone(), &suggestions, self.prev_selection)
         } else {
             let suggestion = self.suggestion.suggest_only_phonetic(&self.buffer);
 

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 pub enum Suggestion {
     Full {
         auxiliary: String,
-        suggestions: Vec<Rank>,
+        suggestions: Vec<String>,
         // Index of the last selected suggestion.
         selection: usize,
     },
@@ -25,10 +25,10 @@ impl Suggestion {
     /// `suggestions`: Vector of suggestions.
     ///
     /// `selection`: Index of the last selected suggestion.
-    pub fn new(auxiliary: String, suggestions: Vec<Rank>, selection: usize) -> Self {
+    pub fn new(auxiliary: String, suggestions: &[Rank], selection: usize) -> Self {
         Self::Full {
             auxiliary,
-            suggestions,
+            suggestions: suggestions.iter().map(|r| r.to_string().to_owned()).collect(),
             selection,
         }
     }
@@ -68,9 +68,9 @@ impl Suggestion {
     }
 
     /// Get the suggestions as an iterator.
-    pub fn get_suggestions(&self) -> impl Iterator<Item = &str> {
+    pub fn get_suggestions(&self) -> &[String] {
         match &self {
-            Self::Full { suggestions, .. } => suggestions.iter().map(Rank::to_string),
+            Self::Full { suggestions, .. } => suggestions,
             _ => panic!(),
         }
     }


### PR DESCRIPTION
So we'll not need to reconstitute the vector just to deallocate it afterward.

cc @gulshan 