### PR TITLE
Whole word deletion feature

### DIFF
--- a/include/riti.h
+++ b/include/riti.h
@@ -314,10 +314,13 @@ void riti_context_finish_input_session(RitiContext *ptr);
 
  Returns a new `suggestion` after applying the BackSpace event.
 
+ If the `ctrl` parameter is true then it deletes the whole word
+ in composition currently and ends the ongoing input session.
+
  If the internal buffer becomes empty, this function will
  end the ongoing input session.
  */
-Suggestion *riti_context_backspace_event(RitiContext *ptr);
+Suggestion *riti_context_backspace_event(RitiContext *ptr, bool ctrl);
 
 void riti_suggestion_free(Suggestion *ptr);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -61,11 +61,14 @@ impl RitiContext {
     /// A BackSpace event.
     ///
     /// Returns a new `suggestion` after applying the BackSpace event.
+    /// 
+    /// If the `ctrl` parameter is true then it deletes the whole word
+    /// in composition currently and ends the ongoing input session.
     ///
     /// If the internal buffer becomes empty, this function will
     /// end the ongoing input session.
-    pub fn backspace_event(&self) -> Suggestion {
-        self.method.borrow_mut().backspace_event(&self.data, &self.config)
+    pub fn backspace_event(&self, ctrl: bool) -> Suggestion {
+        self.method.borrow_mut().backspace_event(ctrl, &self.data, &self.config)
     }
 }
 
@@ -75,7 +78,7 @@ pub(crate) trait Method {
     fn update_engine(&mut self, config: &Config);
     fn ongoing_input_session(&self) -> bool;
     fn finish_input_session(&mut self);
-    fn backspace_event(&mut self, data: &Data, config: &Config) -> Suggestion;
+    fn backspace_event(&mut self, ctrl: bool, data: &Data, config: &Config) -> Suggestion;
 }
 
 impl dyn Method {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -106,16 +106,19 @@ pub extern "C" fn riti_context_finish_input_session(ptr: *mut RitiContext) {
 ///
 /// Returns a new `suggestion` after applying the BackSpace event.
 ///
+/// If the `ctrl` parameter is true then it deletes the whole word
+/// in composition currently and ends the ongoing input session.
+/// 
 /// If the internal buffer becomes empty, this function will
 /// end the ongoing input session.
 #[no_mangle]
-pub extern "C" fn riti_context_backspace_event(ptr: *mut RitiContext) -> *mut Suggestion {
+pub extern "C" fn riti_context_backspace_event(ptr: *mut RitiContext, ctrl: bool) -> *mut Suggestion {
     let context = unsafe {
         assert!(!ptr.is_null());
         &*ptr
     };
 
-    let suggestion = context.backspace_event();
+    let suggestion = context.backspace_event(ctrl);
 
     Box::into_raw(Box::new(suggestion))
 }

--- a/src/phonetic/method.rs
+++ b/src/phonetic/method.rs
@@ -126,8 +126,14 @@ impl Method for PhoneticMethod {
         self.buffer.clear();
     }
 
-    fn backspace_event(&mut self, data: &Data, config: &Config) -> Suggestion {
+    fn backspace_event(&mut self, ctrl: bool, data: &Data, config: &Config) -> Suggestion {
         if !self.buffer.is_empty() {
+            // Whole word deletion: Ctrl + Backspace combination
+            if ctrl {
+                self.buffer.clear();
+                return Suggestion::empty();
+            }
+
             // Remove the last character.
             self.buffer.pop();
 
@@ -172,7 +178,14 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(!method.backspace_event(&data, &config).is_empty()); // a
-        assert!(method.backspace_event(&data, &config).is_empty()); // Empty
+        assert!(!method.backspace_event(false, &data, &config).is_empty()); // a
+        assert!(method.backspace_event(false, &data, &config).is_empty()); // Empty
+
+        // Ctrl + Backspace
+        method = PhoneticMethod {
+            buffer: "ab".to_string(),
+            ..Default::default()
+        };
+        assert!(method.backspace_event(true, &data, &config).is_empty());
     }
 }


### PR DESCRIPTION
AKA <kbd>Ctrl</kbd> + <kbd>Backspace</kbd> combination which deletes the whole word in composition currently.

Partially addresses OpenBangla/OpenBangla-Keyboard#299