### PR TITLE
Use the `upodesh` crate for dictionary suggestion search

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         rust:
           - stable
           - 1.63.0 # MSRV for linux distributions (>= Debian 12)
-          - nightly
+          # - nightly  # To keep the MSRV, we can't test with nightly as some downgraded crates fails to compile
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ stringplus = "0.1"
 edit-distance = "2.1"
 okkhor = { version = "0.7", features = ["regex"] }
 poriborton = "0.2"
+upodesh = "0.2"
 
 [dev-dependencies]
 rustversion = "1.0"


### PR DESCRIPTION
`upodesh` uses an approach based on the Finite State Transducer (FST) data structure which is substantially faster than the Regular Expression based approach. This approach is inspired by the Go project [`libavrophonetic`](https://github.com/mugli/libavrophonetic/) of Mehdi Hasan Khan which used Trie data structure.

### Benchmarks
`upodesh` is significantly faster than the previously used heavily optimized regex-based search approach in `riti`. Based on recent benchmarks, it is approximately ~21× to ~58× faster, depending on the input. This demonstrates a substantial performance gain over regex, especially in cases where large patterns previously caused bottlenecks.
### 📊 Summary of the Benchmark
This benchmark was performed on a Apple MacBook Air M1:

| Word   | `upodesh` Time | `regex` Time | Speedup         |
| --------- | -------------- | ------------ | --------------- |
| `a`       | ~3.341 µs      | ~194.34 µs    | **\~58× faster**  |
| `arO`     | ~11.840 µs      | ~246.53 µs    | **\~20.8× faster**  |
| `bistari` | ~9.734 µs      | ~353.74 µs    | **\~36.3× faster** |


cc @mugli @gulshan 